### PR TITLE
Remove extended chars in source (#11)

### DIFF
--- a/WinMain.cpp
+++ b/WinMain.cpp
@@ -1075,7 +1075,7 @@ void game_engine::render_map(void){//renders game map
 	if(!paused)
 	if(fabs(time_from_beginning-creatures_checked_on)>check_time)
 	{
-		map_main->check_creatures();//t�t� voi tehd� v�h�n harvemmin jos haluaa
+		map_main->check_creatures();
 		creatures_checked_on=time_from_beginning+randDouble(0,check_time*0.25f);
 
 	}
@@ -9272,7 +9272,7 @@ void game_engine::draw_item_view(void){
 
 
 
-	int mahtuu=13;//montako rivi� mahtuu listaan
+	int mahtuu=13;
 
 
 
@@ -9286,7 +9286,7 @@ void game_engine::draw_item_view(void){
 
 			int rivi=0;
 			int ohirivit=0;
-			int total_items=0;//montako yhteens�
+			int total_items=0;
 
 			grim->System_SetState_Blending(true);
 			grim->System_SetState_BlendSrc(grBLEND_SRCALPHA);
@@ -10468,7 +10468,7 @@ void game_engine::render_credits(void){
 	grim->Quads_SetColor(1,1,1,1);
 	text_manager.write_line(font,147/1024.0f*screen_width,68/768.0f*screen_height,"Notrium "+game_version,3/1024.0f*screen_width);
 
-	string credits("Developed by: Ville M�nkk�nen \\ In association with: Michael Quigley aka Quanrian \\ Music by: Kush Diarra  \\ Based on design by: Mikko Tikkanen \\ Using Grim 2D graphics engine \\ \\ Beta crew: \\ Robbie BT aka ZeXLR8er!! \\ Sergio Enriquez aka Torment aka Casanova \\ Nick Atherley aka Eternal \\ Carl S. aka Click \\ \\ \\ Press enter to continue");
+	string credits("Developed by: Ville M\u00F6nkk\u00F6nen \\ In association with: Michael Quigley aka Quanrian \\ Music by: Kush Diarra  \\ Based on design by: Mikko Tikkanen \\ Using Grim 2D graphics engine \\ \\ Beta crew: \\ Robbie BT aka ZeXLR8er!! \\ Sergio Enriquez aka Torment aka Casanova \\ Nick Atherley aka Eternal \\ Carl S. aka Click \\ \\ \\ Press enter to continue");
 
 
 
@@ -11581,7 +11581,7 @@ void game_engine::render_menu(void){
 	//version
 	grim->System_SetState_Blending(true);
 	grim->Quads_SetColor(1,1,1,1);
-	text_manager.write_line(font,2/1024.0f*screen_width,747/768.0f*screen_height,"Copyright 2005 Ville M�nkk�nen    Version "+game_version,1/1024.0f*screen_width);
+	text_manager.write_line(font,2/1024.0f*screen_width,747/768.0f*screen_height,"Copyright 2005 Ville M\u00F6nkk\u00F6nen    Version "+game_version,1/1024.0f*screen_width);
 
 	//text_manager.write_line(font,13/1024.0f*screen_width,600/768.0f*screen_height,"TEST VERSION - DO NOT DISTRIBUTE",3/1024.0f*screen_width);
 	//text_manager.write_line(font,13/1024.0f*screen_width,650/768.0f*screen_height,"Remember to take screenshots!",3/1024.0f*screen_width);

--- a/func.cpp
+++ b/func.cpp
@@ -392,11 +392,11 @@ bool isvowel(char character){
 		return true;
 	case 'y':
 		return true;
-	case 'ä':
+	case '\u00E5': //lowercase a with ring
 		return true;
-	case 'ö':
+	case '\u00E4': //lowercase o with ring
 		return true;
-	case 'å':
+	case '\u00F6': //lowercase o diaeresis
 		return true;
 	case 'A':
 		return true;
@@ -410,11 +410,11 @@ bool isvowel(char character){
 		return true;
 	case 'Y':
 		return true;
-	case 'Ä':
+	case '\u00C4': //uppercase a diaeresis
 		return true;
-	case 'Ö':
+	case '\u00D5': //uppercase o diaeresis
 		return true;
-	case 'Å':
+	case '\u00C5': //uppercase a with ring
 		return true;
 	}
 	return false;

--- a/text_output.cpp
+++ b/text_output.cpp
@@ -62,19 +62,16 @@ void text_output::write(int font, const string& text, float size, float x0,float
 	int rivi=0;
 	int a=0;
 
-	//kirjain kerrallaan kunnes tulee loppu tai väli
 	while(true){
 		if(a>=teksti_pituus)break;
-			//väli
 			if((text[a]==' ')||(a==teksti_pituus-1)){
-				if(rivi*rivi_korkeus>y1-y0)return;//alareuna tuli vastaan, lopetetaan
+				if(rivi*rivi_korkeus>y1-y0)return;//lower edge, stop
 
-				if(x_cursor>rivin_pituus){//on menty rivin reunan yli, vaihdetaan riviä
+				if(x_cursor>rivin_pituus){//gone over end of line, change line
 					x_cursor=0;
 					rivi++;
 				}
 
-				//tulostetaan sana tähän
 				sana_loppu=a+1;
 				for(int b=sana_alku;b<sana_loppu;b++){
 					find_letter_width(text[b],&nume,&kirjainleveys);
@@ -88,13 +85,12 @@ void text_output::write(int font, const string& text, float size, float x0,float
 						grim->Quads_Draw(x0+x_cursor, y0+rivi*rivi_korkeus, letter_width*size, letter_height*size);
 					}
 
-					//rivinvaihto
+					//newline
 					if(kirjainleveys==-1)x_cursor=rivin_pituus;
 
 
 					x_cursor+=(kirjainleveys+3)*size*0.5f;
 				}
-				//seuraavan sanan alku on tämän loppu
 				sana_alku=a+1;
 				sana_loppu=a+1;
 
@@ -138,9 +134,9 @@ void text_output::find_letter_width(char kirjain, int *nume, int *kirjainleveys)
 			case 'x':{*kirjainleveys=16;*nume=53;break;}
 			case 'y':{*kirjainleveys=16;*nume=54;break;}
 			case 'z':{*kirjainleveys=16;*nume=55;break;}
-			case 'å':{*kirjainleveys=16;*nume=56;break;}
-			case 'ä':{*kirjainleveys=16;*nume=57;break;}
-			case 'ö':{*kirjainleveys=16;*nume=58;break;}
+			case '\u00E5':{*kirjainleveys=16;*nume=56;break;} //lowercase a with ring
+			case '\u00E4':{*kirjainleveys=16;*nume=57;break;} //lowercase a diaeresis
+			case '\u00F6':{*kirjainleveys=16;*nume=58;break;} //lowercase o diaeresis
 			case '0':{*kirjainleveys=16;*nume=59;break;}
 			case '1':{*kirjainleveys=8;*nume=60;break;}
 			case '2':{*kirjainleveys=16;*nume=61;break;}
@@ -155,7 +151,7 @@ void text_output::find_letter_width(char kirjain, int *nume, int *kirjainleveys)
 			case '.':{*kirjainleveys=8;*nume=70;break;}
 			case '/':{*kirjainleveys=14;*nume=71;break;}
 			case ':':{*kirjainleveys=8;*nume=72;break;}
-			case '´':{*kirjainleveys=6;*nume=73;break;}
+			case '\'':{*kirjainleveys=6;*nume=73;break;}
 			case 0x27:{*kirjainleveys=6;*nume=73;break;}
 			case '?':{*kirjainleveys=16;*nume=74;break;}
 			case ',':{*kirjainleveys=8;*nume=75;break;}
@@ -192,9 +188,9 @@ void text_output::find_letter_width(char kirjain, int *nume, int *kirjainleveys)
 			case 'X':{*kirjainleveys=16;*nume=24;break;}
 			case 'Y':{*kirjainleveys=16;*nume=25;break;}
 			case 'Z':{*kirjainleveys=16;*nume=26;break;}
-			case 'Å':{*kirjainleveys=16;*nume=27;break;}
-			case 'Ä':{*kirjainleveys=16;*nume=28;break;}
-			case 'Ö':{*kirjainleveys=16;*nume=29;break;}
+			case '\u00C5':{*kirjainleveys=16;*nume=27;break;} //uppercase a with ring
+			case '\u00C4':{*kirjainleveys=16;*nume=28;break;} //uppercase a diaeresis
+			case '\u00D5':{*kirjainleveys=16;*nume=29;break;} //uppercase o diaeresis
 		}
 }
 


### PR DESCRIPTION
Seems to fix #11.

The trick is that all characters used in font.png still fit within a single byte. The resulting strings are not Unicode, but since we match char-by-char, it still works.

... Until I'm proven wrong, of course.
