### PR TITLE
C++11 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,4 +23,14 @@ link_libraries(
     ${SDL_IMAGE_LIBRARIES}
     ${PHYSFS_LIBRARY})
 
+# Add C++11 support flags to GCC
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+if(COMPILER_SUPPORTS_CXX11)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+elseif(COMPILER_SUPPORTS_CXX0X)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+endif()
+
 add_executable(OpenNotrium ${OpenNotrium_sources})

--- a/WinMain.cpp
+++ b/WinMain.cpp
@@ -4,9 +4,12 @@
 
 #include <iostream>
 
-#ifndef isnan
-#define isnan(x) _isnan(x)
-#endif
+// In C++11, isnan is a function, not a macro.
+// If your compiler fails to find std::isnan, try
+// uncommenting this or writing a less intrusive solution.
+//#if !defined(isnan) && defined(_isnan)
+//#define isnan(x) _isnan(x)
+//#endif
 
 //#define RELEASE(x) {if (x) {(x)->Release(); (x)=NULL;}}
 template<typename T>

--- a/main.h
+++ b/main.h
@@ -18,6 +18,7 @@
 #include <vector>
 #include <list>
 #include <algorithm>
+#include <cmath>
 
 #include "resource_handler.h"
 #include "entities.h"


### PR DESCRIPTION
This pull request include the means of migrating Open Notrium to C++11. Hopefully after this is merged, we may do things nicer than before.

Nearly everything is backwards compatible. `isnan` is an exception, where it now is defined as the function `std::isnan` in `<cmath>`. Before C++11, the compiler would probably have `isnan` or `_isnan` as macros or functions. I have included `<cmath>` where this function was being used, in hope that all C++11-compliant compilers will find it.

One of the nicest things we can do with C++11 in WinMain.cpp is to create references to objects of an invisible type. For instance, WinMain.cpp:17186 has some ugly and long lines of code, having to write the full member path in order to access `mod.polygons[mod.general_objects[object->type].collision_parameter0].points` or `object_size*mod.general_objects[object->type].collision_parameter1`. The first reaction to simplifying this code is aliasing it with a reference type. However, there are two problems:
- If the object we're trying to alias is of an invisible type, then we cannot create the reference without changing the visibility of the type.
- Even if it isn't, what's its type? Sometimes it's pretty damn hard to figure out, especially without an IDE.

With C++11, we can use the auto keyword: `auto& points = mod.polygons[mod.general_objects[object->type].collision_parameter0].points;`
