### PR TITLE
Change cmake find modules for SDL2 libraries

### DIFF
--- a/FindSDL2_image.cmake
+++ b/FindSDL2_image.cmake
@@ -1,24 +1,20 @@
-#.rst:
-# FindSDL_image
-# -------------
-#
-# Locate SDL_image library
-#
+# - Locate SDL_image library
 # This module defines:
+#  SDL2_IMAGE_LIBRARIES, the name of the library to link against
+#  SDL2_IMAGE_INCLUDE_DIRS, where to find the headers
+#  SDL2_IMAGE_FOUND, if false, do not try to link against
+#  SDL2_IMAGE_VERSION_STRING - human-readable string containing the version of SDL_image
 #
-# ::
+# For backward compatiblity the following variables are also set:
+#  SDLIMAGE_LIBRARY (same value as SDL2_IMAGE_LIBRARIES)
+#  SDLIMAGE_INCLUDE_DIR (same value as SDL2_IMAGE_INCLUDE_DIRS)
+#  SDLIMAGE_FOUND (same value as SDL2_IMAGE_FOUND)
 #
-#   SDL2_IMAGE_LIBRARIES, the name of the library to link against
-#   SDL2_IMAGE_INCLUDE_DIRS, where to find the headers
-#   SDL2_IMAGE_FOUND, if false, do not try to link against
-#   SDL2_IMAGE_VERSION_STRING - human-readable string containing the version of SDL_image
+# $SDLDIR is an environment variable that would
+# correspond to the ./configure --prefix=$SDLDIR
+# used in building SDL.
 #
-#
-#
-# $SDL2DIR is an environment variable that would correspond to the
-# ./configure --prefix=$SDL2DIR used in building SDL.
-#
-# Created by Eric Wing.  This was influenced by the FindSDL.cmake
+# Created by Eric Wing. This was influenced by the FindSDL.cmake
 # module, but with modifications to recognize OS X frameworks and
 # additional Unix paths (FreeBSD, etc).
 
@@ -36,27 +32,48 @@
 # (To distribute this file outside of CMake, substitute the full
 #  License text for the above reference.)
 
-find_path(SDL2_IMAGE_INCLUDE_DIRS SDL_image.h
-  HINTS
-    ENV SDL2IMAGEDIR
-    ENV SDL2DIR
-  PATH_SUFFIXES SDL
-                # path suffixes to search inside ENV{SDL2DIR}
-                include/SDL include/SDL12 include/SDL11 include
+SET(SDL2_SEARCH_PATHS
+	~/Library/Frameworks
+	/Library/Frameworks
+	/usr/local
+	/usr
+	/sw # Fink
+	/opt/local # DarwinPorts
+	/opt/csw # Blastwave
+	/opt
 )
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-  set(VC_LIB_PATH_SUFFIX lib/x64)
+  set(SDL2_ARCH_64 TRUE)
+  set(SDL2_PROCESSOR_ARCH "x64")
 else()
-  set(VC_LIB_PATH_SUFFIX lib/x86)
-endif()
+  set(SDL2_ARCH_64 FALSE)
+  set(SDL2_PROCESSOR_ARCH "x86")
+endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
 
-find_library(SDL2_IMAGE_LIBRARIES
+if(NOT SDL2_IMAGE_INCLUDE_DIR AND SDL2IMAGE_INCLUDE_DIR)
+  set(SDL2_IMAGE_INCLUDE_DIR ${SDL2IMAGE_INCLUDE_DIR} CACHE PATH "directory cache
+entry initialized from old variable name")
+endif()
+find_path(SDL2_IMAGE_INCLUDE_DIR SDL_image.h
+  HINTS
+    ENV SDL2IMAGEDIR
+    ENV SDL2DIR
+  PATH_SUFFIXES include include/SDL2
+  PATHS ${SDL2_SEARCH_PATHS}
+)
+
+if(NOT SDL2_IMAGE_LIBRARY AND SDL2IMAGE_LIBRARY)
+  set(SDL2_IMAGE_LIBRARY ${SDL2IMAGE_LIBRARY} CACHE FILEPATH "file cache entry
+initialized from old variable name")
+endif()
+find_library(SDL2_IMAGE_LIBRARY
   NAMES SDL2_image
   HINTS
     ENV SDL2IMAGEDIR
     ENV SDL2DIR
-  PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+  PATH_SUFFIXES lib64 lib lib/${SDL2_PROCESSOR_ARCH}
+  PATHS ${SDL2_SEARCH_PATHS}
 )
 
 if(SDL2_IMAGE_INCLUDE_DIR AND EXISTS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h")
@@ -75,7 +92,18 @@ if(SDL2_IMAGE_INCLUDE_DIR AND EXISTS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h")
   unset(SDL2_IMAGE_VERSION_PATCH)
 endif()
 
+set(SDL2_IMAGE_LIBRARIES ${SDL2_IMAGE_LIBRARY})
+set(SDL2_IMAGE_INCLUDE_DIRS ${SDL2_IMAGE_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_image
                                   REQUIRED_VARS SDL2_IMAGE_LIBRARIES SDL2_IMAGE_INCLUDE_DIRS
                                   VERSION_VAR SDL2_IMAGE_VERSION_STRING)
 
+# for backward compatiblity
+set(SDL2IMAGE_LIBRARY ${SDL2_IMAGE_LIBRARIES})
+set(SDL2IMAGE_INCLUDE_DIR ${SDL2_IMAGE_INCLUDE_DIRS})
+set(SDL2IMAGE_FOUND ${SDL2_IMAGE_FOUND})
+
+mark_as_advanced(SDL2_IMAGE_LIBRARY SDL2_IMAGE_INCLUDE_DIR)

--- a/FindSDL2_mixer.cmake
+++ b/FindSDL2_mixer.cmake
@@ -1,25 +1,20 @@
-#.rst:
-# FindSDL2_mixer
-# -------------
-#
-# Locate SDL2_mixer library
-#
+# - Locate SDL_mixer library
 # This module defines:
+#  SDL2_MIXER_LIBRARIES, the name of the library to link against
+#  SDL2_MIXER_INCLUDE_DIRS, where to find the headers
+#  SDL2_MIXER_FOUND, if false, do not try to link against
+#  SDL2_MIXER_VERSION_STRING - human-readable string containing the version of SDL_mixer
 #
-# ::
+# For backward compatiblity the following variables are also set:
+#  SDLMIXER_LIBRARY (same value as SDL2_MIXER_LIBRARIES)
+#  SDLMIXER_INCLUDE_DIR (same value as SDL2_MIXER_INCLUDE_DIRS)
+#  SDLMIXER_FOUND (same value as SDL2_MIXER_FOUND)
 #
-#   SDL2_MIXER_LIBRARIES, the name of the library to link against
-#   SDL2_MIXER_INCLUDE_DIRS, where to find the headers
-#   SDL2_MIXER_FOUND, if false, do not try to link against
-#   SDL2_MIXER_VERSION_STRING - human-readable string containing the version of SDL_mixer
+# $SDLDIR is an environment variable that would
+# correspond to the ./configure --prefix=$SDLDIR
+# used in building SDL.
 #
-#
-#
-#
-# $SDL2DIR is an environment variable that would correspond to the
-# ./configure --prefix=$SDL2DIR used in building SDL.
-#
-# Created by Eric Wing.  This was influenced by the FindSDL.cmake
+# Created by Eric Wing. This was influenced by the FindSDL.cmake
 # module, but with modifications to recognize OS X frameworks and
 # additional Unix paths (FreeBSD, etc).
 
@@ -37,27 +32,48 @@
 # (To distribute this file outside of CMake, substitute the full
 #  License text for the above reference.)
 
-find_path(SDL2_MIXER_INCLUDE_DIRS SDL_mixer.h
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(SDL2_ARCH_64 TRUE)
+  set(SDL2_PROCESSOR_ARCH "x64")
+else()
+  set(SDL2_ARCH_64 FALSE)
+  set(SDL2_PROCESSOR_ARCH "x86")
+endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+
+SET(SDL2_SEARCH_PATHS
+	~/Library/Frameworks
+	/Library/Frameworks
+	/usr/local
+	/usr
+	/sw # Fink
+	/opt/local # DarwinPorts
+	/opt/csw # Blastwave
+	/opt
+)
+
+if(NOT SDL2_MIXER_INCLUDE_DIR AND SDL2MIXER_INCLUDE_DIR)
+  set(SDL2_MIXER_INCLUDE_DIR ${SDL2MIXER_INCLUDE_DIR} CACHE PATH "directory cache
+entry initialized from old variable name")
+endif()
+find_path(SDL2_MIXER_INCLUDE_DIR SDL_mixer.h
   HINTS
     ENV SDL2MIXERDIR
     ENV SDL2DIR
-  PATH_SUFFIXES SDL
-                # path suffixes to search inside ENV{SDLDIR}
-                include/SDL include/SDL12 include/SDL11 include
+  PATH_SUFFIXES include include/SDL2
+  PATHS ${SDL2_SEARCH_PATHS}
 )
 
-if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-  set(VC_LIB_PATH_SUFFIX lib/x64)
-else()
-  set(VC_LIB_PATH_SUFFIX lib/x86)
+if(NOT SDL2_MIXER_LIBRARY AND SDL2MIXER_LIBRARY)
+  set(SDL2_MIXER_LIBRARY ${SDL2MIXER_LIBRARY} CACHE FILEPATH "file cache entry
+initialized from old variable name")
 endif()
-
-find_library(SDL2_MIXER_LIBRARIES
+find_library(SDL2_MIXER_LIBRARY
   NAMES SDL2_mixer
   HINTS
     ENV SDL2MIXERDIR
     ENV SDL2DIR
-  PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+  PATH_SUFFIXES lib64 lib lib/${SDL2_PROCESSOR_ARCH}
+  PATHS ${SDL2_SEARCH_PATHS}
 )
 
 if(SDL2_MIXER_INCLUDE_DIR AND EXISTS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h")
@@ -76,7 +92,18 @@ if(SDL2_MIXER_INCLUDE_DIR AND EXISTS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h")
   unset(SDL2_MIXER_VERSION_PATCH)
 endif()
 
+set(SDL2_MIXER_LIBRARIES ${SDL2_MIXER_LIBRARY})
+set(SDL2_MIXER_INCLUDE_DIRS ${SDL2_MIXER_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_mixer
                                   REQUIRED_VARS SDL2_MIXER_LIBRARIES SDL2_MIXER_INCLUDE_DIRS
                                   VERSION_VAR SDL2_MIXER_VERSION_STRING)
 
+# for backward compatiblity
+set(SDL2MIXER_LIBRARY ${SDL2_MIXER_LIBRARIES})
+set(SDL2MIXER_INCLUDE_DIR ${SDL2_MIXER_INCLUDE_DIRS})
+set(SDL2MIXER_FOUND ${SDL2_MIXER_FOUND})
+
+mark_as_advanced(SDL2_MIXER_LIBRARY SDL2_MIXER_INCLUDE_DIR)


### PR DESCRIPTION
The previous find modules didn't find mixer nor image on Debian. These
I've taken from
https://github.com/Gear2D/gear2d-components/tree/master/cmake
, and they work.