### PR TITLE
Iss40 fix mac build

### DIFF
--- a/README
+++ b/README
@@ -45,6 +45,19 @@ We will also assume you have the OpenNotrium source files checked out in ~/OpenN
   cd out
   ./OpenNotrium
 
+HOW TO BUILD - Mac
+We highly suggest using a package manager for Mac, either fink, MacPorts or Homebrew. Underneath Homebrew is used.
+
+1. Get XCode command line tools running
+You should search online for this. It involves registering an Apple developer account, downloading XCode, and installing the command line tools from there.
+
+2. Install CMake
+brew install cmake
+
+3. Install dependencies
+brew install sdl2 sdl2_mixer physfs
+
+4. Follow Linux guidelines from step 3 onwards.
 
 HOW TO BUILD - Windows - Visual Studio
 
@@ -56,7 +69,7 @@ Physfs doesn't provide binaries on Windows. Google, download and unpack. Then, f
 
 3. Google, download and unpack, SDL 2.0, SDL_image 2.0 and SDL_mixer 2.0. Make sure to get the VS-development archives. It is highly recommended to unpack the libraries to the same directory, this helps with the next steps.
 
-4. Create environment variables for the libraries so CMake can find them. Set the paths below to where you unpacked 
+4. Create environment variables for the libraries so CMake can find them. Set the paths below to where you unpacked
 setx SDLDIR c:\sdl2
 setx PHYSFSDIR c:\physfs
 

--- a/WinMain.cpp
+++ b/WinMain.cpp
@@ -14,7 +14,9 @@
 
 #define WM_GRAPHNOTIFY  WM_APP + 1
 
-using namespace std;
+using std::vector;
+using std::list;
+using std::string;
 using namespace Debugger;
 
 Engine *grim = NULL;
@@ -58,7 +60,7 @@ void game_engine::GetScreenshotFileName(string& FileName)
     string buffer;
     for (int i = 0; i < 1000; i++)
     {
-		ostringstream os;
+		std::ostringstream os;
 		os << "shot" << i << ".bmp";
 		buffer = os.str();
 
@@ -570,7 +572,7 @@ int main(int argc, char* argv[])
 	grim->System_SetState_FocusGainFunc(focusgained);
 
 	if (!engine->cfg_load()) {
-        cerr << "Config file not found." << endl;
+        std::cerr << "Config file not found." << std::endl;
         delete engine;
         delete grim;
         return -1;
@@ -17150,5 +17152,3 @@ void game_engine::draw_map_grid_small(map *map_to_edit, int texture, int texture
 
 
 }
-
-


### PR DESCRIPTION
After reading up on namespaces, I propose this quick-fix for getting the mac build to work. Guarding our own code with namespaces would probably be better, but would require quite some changes to the headers, so I'm not sure it's a great idea right now. Opinions, @Enet4 ?