### PR TITLE
Solve SDL memory leaks

### DIFF
--- a/engine.cpp
+++ b/engine.cpp
@@ -2,7 +2,7 @@
 #include <SDL.h>
 #include <SDL_image.h>
 #include "func.h"
-#include "physfs.h"
+#include <physfs.h>
 
 Engine::Engine()
 :   window(nullptr)
@@ -426,9 +426,10 @@ bool Engine::Texture_Load(const std::string& id, char *filename){
 
     createNewTexture(id,surface->w, surface->h);
 
-	glTexImage2D( GL_TEXTURE_2D, 0, nOfColors, surface->w, surface->h, 0,
+	  glTexImage2D( GL_TEXTURE_2D, 0, nOfColors, surface->w, surface->h, 0,
                       texture_format, GL_UNSIGNED_BYTE, surface->pixels );
-
+    // assuming the texture was copied to OpenGL, the surface is no longer needed
+    SDL_FreeSurface(surface);
     return true;
 }
 

--- a/resource_handler.cpp
+++ b/resource_handler.cpp
@@ -93,19 +93,16 @@ int resource_handler::load_sample(const string& name, int samples, const string&
 		strcat(temprivi,mod_name.c_str());
 		strcat(temprivi,"/");
 		strcat(temprivi,name.c_str());
-		res=g_pSoundManager->Create( &sample[samples_loaded], temprivi );
-
-
+		res=g_pSoundManager->Create(sample[samples_loaded], temprivi );
 
 		//try default directory
 		if(!res){
 			SAFE_DELETE(sample[samples_loaded]);
 			strcpy(temprivi,"sound/");
 			strcat(temprivi,name.c_str());
-			res=g_pSoundManager->Create( &sample[samples_loaded], temprivi );
+			res = g_pSoundManager->Create(sample[samples_loaded], temprivi );
 		}
-
-		if(res){
+		if (res) {
 			//store name
 			sample_name[samples_loaded]=name;
 			sample_name_mod[samples_loaded]=mod_name;

--- a/soundmanager.cpp
+++ b/soundmanager.cpp
@@ -39,7 +39,6 @@ void SoundManager::setMusicVolume(float volume){
     Mix_VolumeMusic(volume*MIX_MAX_VOLUME);
 }
 
-// ctor
 SoundSample::SoundSample(const char *filename,int freq,int bytes){
     //TODO: the delay seems solvable by using VC++ compiler/libs and DirectSound
     chunk = Mix_LoadWAV(filename);
@@ -47,7 +46,6 @@ SoundSample::SoundSample(const char *filename,int freq,int bytes){
     bytespersample = bytes;
 }
 
-// dtor
 SoundSample::~SoundSample(void) {
     if (chunk) {
       Mix_FreeChunk(chunk);

--- a/soundmanager.cpp
+++ b/soundmanager.cpp
@@ -2,13 +2,10 @@
 
 #include <SDL.h>
 
-bool SoundManager::Create(SoundSample** dest, const char *filename)
+bool SoundManager::Create(SoundSample*& dest, const char *filename)
 {
-    *dest = new SoundSample(filename, samplefreq, bytespersample);
-    if(!(*dest)->initOkay()){
-        return false;
-    }
-    return true;
+    dest = new SoundSample(filename, samplefreq, bytespersample);
+    return dest->initOkay();
 }
 
 bool SoundManager::Initialize(int freq, int channels)
@@ -42,11 +39,19 @@ void SoundManager::setMusicVolume(float volume){
     Mix_VolumeMusic(volume*MIX_MAX_VOLUME);
 }
 
+// ctor
 SoundSample::SoundSample(const char *filename,int freq,int bytes){
     //TODO: the delay seems solvable by using VC++ compiler/libs and DirectSound
     chunk = Mix_LoadWAV(filename);
     samplefreq = freq;
     bytespersample = bytes;
+}
+
+// dtor
+SoundSample::~SoundSample(void) {
+    if (chunk) {
+      Mix_FreeChunk(chunk);
+    }
 }
 
 bool SoundSample::initOkay(void){

--- a/soundmanager.h
+++ b/soundmanager.h
@@ -8,13 +8,13 @@ class SoundSample
     Mix_Chunk* chunk;
     int samplefreq, bytespersample; //TODO: this does not quite belong here, I think
 public:
-    /** ctor */
     SoundSample(const char *filename, int samplefreq, int bytespersample);
     
-    /** copy ctor is deleted */
+    /** copy ctor is deleted because it's unsafe
+     * (the mix chunk pointer requires proper memory management)
+     */
     SoundSample(const SoundSample& other) = delete;
 
-    /** dtor */
     ~SoundSample(void);
 
     bool initOkay(void);

--- a/soundmanager.h
+++ b/soundmanager.h
@@ -8,7 +8,14 @@ class SoundSample
     Mix_Chunk* chunk;
     int samplefreq, bytespersample; //TODO: this does not quite belong here, I think
 public:
+    /** ctor */
     SoundSample(const char *filename, int samplefreq, int bytespersample);
+    
+    /** copy ctor is deleted */
+    SoundSample(const SoundSample& other) = delete;
+
+    /** dtor */
+    ~SoundSample(void);
 
     bool initOkay(void);
     /**
@@ -30,7 +37,7 @@ class SoundManager
     static const int numchannels = 64;
     Mix_Music *currentmusic;
 public:
-    bool Create( SoundSample** dest, const char *filename );
+    bool Create( SoundSample*& dest, const char *filename );
 
     /**
     * For now, let us assume signed 16 bit data.


### PR DESCRIPTION
- Added a destructor to `SoundSample` that frees its SDL mixer chunk;
- Freed SDL surface associated to loaded textures after creating an OpenGL texture with them;
- related minor tweaks

It solves the insane memory leak in #47, but not all of the problems surrounding it. 
- I still get spammed with console warnings: "libpng warning: Interlace handling should be turned on when using png_read_image" and "libpng warning: iCCP: known incorrect sRGB profile".
- Performance is still not optimal: it's a very demanding map, and we should seek to improve the performance of our code.
- Doesn't fix all leaks in the code. Valgrind suggests that there are a few more leaks around (but this fix makes a huge difference):

> ==2870== 
> ==2870== HEAP SUMMARY:
> ==2870==     in use at exit: 745,993 bytes in 1,742 blocks
> ==2870==   total heap usage: 770,859 allocs, 769,117 frees, 2,751,621,484 bytes allocated
> ==2870== 
> ==2870== LEAK SUMMARY:
> ==2870==    definitely lost: 2,180 bytes in 124 blocks
> ==2870==    indirectly lost: 115,088 bytes in 610 blocks
> ==2870==      possibly lost: 1,056 bytes in 3 blocks
> ==2870==    still reachable: 627,669 bytes in 1,005 blocks
> ==2870==         suppressed: 0 bytes in 0 blocks
