### PR TITLE
Better screenshot buffer (IMHO)

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -57,7 +57,8 @@ void game_engine::GetScreenshotFileName(string& FileName)
 {
     // search for first unused filename
     string buffer;
-    for (int i = 0; i < 1000; i++)
+    int i = 0;
+    for (;;)
     {
 		std::ostringstream os;
 		os << "shot" << i << ".bmp";
@@ -65,6 +66,8 @@ void game_engine::GetScreenshotFileName(string& FileName)
 
 		if (!grim->File_Exists(buffer))
         {   break; }
+	
+		i++;
     }
 
     // set FileName to the first unused filename


### PR DESCRIPTION
No longer stops and overwrites "shot1000.bmp".

Future TODO:    Add timestamp based screenshot naming. It removes unnecessary file looping or alternative method of storing last name used and increasing that.