### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,59 @@
+language: cpp
+addons:
+  apt:
+    sources:
+      - george-edison55-precise-backports
+    packages:
+      - cmake-data
+      - cmake
+matrix:
+  include:
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.8
+      env:
+         - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+before_install:
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libphysfs-dev
+    - eval "${MATRIX_EVAL}"
+
+script:
+    - mkdir -p build && cd build
+    - cmake ..
+    - make

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 OpenNotrium
 ===========
 
+[![Build Status](https://travis-ci.org/verhoevenv/OpenNotrium.svg?branch=master)](https://travis-ci.org/verhoevenv/OpenNotrium)
+
 Open source version of Notrium.
 
 Notrium is a top-down survival game originally developed by Ville Mönkkönen.


### PR DESCRIPTION
This configuration file instructs Travis CI to build OpenNotrium on an Ubuntu machine with some versions of GCC (currently 4.8, 5, 6 and 7). In the future, it may be updated to include testing on an OSX machine as well. For testing on Windows, we'll have to look into [AppVeyor](https://www.appveyor.com/).

Of course, you will also have to enable Travis for this project (see [Getting Started](https://docs.travis-ci.com/user/getting-started)). It should be as simple as a flick of a switch.

I've also added a Travis CI badge in the readme file, which will respond automatically to build outcomes.