### PR TITLE
Fix performance regression on excessive texture unloading

### DIFF
--- a/engine.h
+++ b/engine.h
@@ -61,7 +61,7 @@ class Engine
     int render_target;
     int activetexture;
 
-    static const int maxtextures = 200;
+    static const int maxtextures = 1000;
     EngineTexture textures[maxtextures];
     bool freeSlotInList;
     int currtexture;

--- a/resource_handler.cpp
+++ b/resource_handler.cpp
@@ -192,7 +192,7 @@ int resource_handler::load_texture_in_grim(const char *name, const string& mod_n
 	if(texture_number==-1){
 		//we're still unable to load the texture, all slots must be full
 		//release some slots
-		unload_unneeded_textures(true);
+		unload_unneeded_textures(false);
 
 		//int bug=1;
 		//char* temp=grim->System_GetErrorMessage();


### PR DESCRIPTION
This solves a major performance regression detected while working on #55 (this matter was also discussed on Gitter). In particular, some maps in the Wazzal II mod (e.g. Errxelz 8) should run much faster now. The problem was two-fold:

- When OpenNotrium runs out of space for textures (there was a hardcoded limit of 200 textures), it calls `unload_unneeded_textures`. If you pass `true` as the argument (which indeed was!), it will clear _every single loaded texture_, which forces the application to reload the necessary textures again in the following frame. This was the reason for the performance hit. If you pass `false` however, it will only attempt to unload textures which haven't been used in the last 300 milliseconds (which is enough to keep all texture used in the last few frames).
- The change above was not enough: It turns out that Wazzal II has more textures than the imposed texture limit (the Textures folder has over 700 images). So I raised it to one thousand.

This still leaves a lot of room for improvements: the texture pool should stretch to fit larger mods when it runs out of space. Plus, I've noticed that texture fetches by name are currently performed with a linear traversal over the array. I'm not sure how often textures are fetched by name, but we could check this out and build a dictionary if we consider this appropriate.