### PR TITLE
Fix Travis-CI failing to fetch SDL dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+sudo: false
 addons:
   apt:
     sources:
@@ -15,6 +16,10 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-4.8
+            - libsdl2-dev
+            - libsdl2-mixer-dev
+            - libsdl2-image-dev
+            - libphysfs-dev
       env:
          - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
 
@@ -25,6 +30,10 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-5
+            - libsdl2-dev
+            - libsdl2-mixer-dev
+            - libsdl2-image-dev
+            - libphysfs-dev
       env:
          - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
 
@@ -35,6 +44,10 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-6
+            - libsdl2-dev
+            - libsdl2-mixer-dev
+            - libsdl2-image-dev
+            - libphysfs-dev
       env:
         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
 
@@ -45,12 +58,14 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-7
+            - libsdl2-dev
+            - libsdl2-mixer-dev
+            - libsdl2-image-dev
+            - libphysfs-dev
       env:
         - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
 
 before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -qq libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev libphysfs-dev
     - eval "${MATRIX_EVAL}"
 
 script:


### PR DESCRIPTION
This should fix the Travis errors that we've been facing recently. This was caused by some strange change in how the Ubuntu machines are installing packages (travis-ci/travis-ci#8317). Sticking the packages to the `addons.apt.packages` field solves the problem.